### PR TITLE
Implement profile page and tighten validation

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -25,6 +25,7 @@
         Bienvenue, <span id="nom-utilisateur" class="text-primary">Utilisateur</span>
     </div>
     <div class="flex items-center gap-4">
+        <a href="profile.html" class="btn btn-ghost">Profil</a>
         <!-- Switch clair/sombre -->
         <label class="cursor-pointer flex items-center gap-2">
             <span class="text-sm">🌞</span>
@@ -48,7 +49,7 @@
     <form id="noteForm" class="grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-4 hidden">
         <input type="text" name="code" placeholder="Code EC (ex: 871.1)" class="input input-bordered" required />
         <input type="text" name="nom" placeholder="Nom de l'EC" class="input input-bordered" required />
-        <input type="number" name="note" step="0.1" placeholder="Note" class="input input-bordered" required />
+        <input type="number" name="note" step="0.01" placeholder="Note" class="input input-bordered" required />
         <input type="number" name="coefficient" step="0.1" placeholder="Coefficient" class="input input-bordered" required />
         <button type="submit" class="btn btn-primary col-span-full">Ajouter la note</button>
     </form>

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -90,12 +90,12 @@ document.addEventListener("DOMContentLoaded", async () => {
                     <td>${ec.code}</td>
                     <td colspan="2">${ec.nom}</td>
                     <td>
-                        <input type="number" min="0" max="20" step="0.1" 
+                        <input type="number" min="0" max="20" step="0.01"
                             data-id="${ec._id}"
                             data-code="${ec.code}"
                             data-nom="${ec.nom}"
                             data-coef="${ec.coefficient}"
-                            value="${ec.note}"
+                            value="${parseFloat(ec.note).toFixed(2)}"
                             class="input input-bordered input-sm w-full"/>
                     </td>
                     <td>${ec.coefficient}</td>
@@ -146,7 +146,7 @@ document.addEventListener("DOMContentLoaded", async () => {
                             "Content-Type": "application/json",
                             Authorization: `Bearer ${token}`
                         },
-                        body: JSON.stringify({ note: valeur })
+                        body: JSON.stringify({ note: Math.round(valeur * 100) / 100 })
                     });
 
                     await chargerNotes();
@@ -183,7 +183,7 @@ document.addEventListener("DOMContentLoaded", async () => {
                         "Content-Type": "application/json",
                         Authorization: `Bearer ${token}`
                     },
-                    body: JSON.stringify({ code, nom, note, coefficient })
+                    body: JSON.stringify({ code, nom, note: Math.round(note * 100) / 100, coefficient })
                 });
 
                 form.reset();

--- a/js/profile.js
+++ b/js/profile.js
@@ -1,0 +1,41 @@
+document.addEventListener("DOMContentLoaded", async () => {
+  const token = localStorage.getItem("token");
+  const id = localStorage.getItem("utilisateurId");
+
+  if (!token || !id) {
+    alert("Veuillez vous reconnecter.");
+    window.location.href = "index.html";
+    return;
+  }
+
+  try {
+    const utilisateur = await apiFetch(`utilisateurs/${id}`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+
+    document.getElementById("info-nom").textContent = utilisateur.nom;
+    document.getElementById("info-prenom").textContent = utilisateur.prenom;
+    document.getElementById("info-email").textContent = utilisateur.email;
+    document.getElementById("info-parcours").textContent = utilisateur.parcours;
+  } catch (err) {
+    alert(err.message || "Erreur de chargement.");
+  }
+
+  const deleteBtn = document.getElementById("deleteAccount");
+  if (deleteBtn) {
+    deleteBtn.addEventListener("click", async () => {
+      if (!confirm("Confirmer la suppression de votre compte ?")) return;
+      try {
+        await apiFetch(`utilisateurs/${id}`, {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        alert("Compte supprimé.");
+        localStorage.clear();
+        window.location.href = "index.html";
+      } catch (err) {
+        alert(err.message || "Erreur de suppression.");
+      }
+    });
+  }
+});

--- a/js/register.js
+++ b/js/register.js
@@ -4,9 +4,17 @@ document.querySelector("form").addEventListener("submit", async (e) => {
     const prenom = document.querySelector("input[name='prenom']").value;
     const nom = document.querySelector("input[name='nom']").value;
     const email = document.querySelector("input[name='email']").value;
+    const emailRegex = /^[\w.-]+@[\w.-]+\.[A-Za-z]{2,}$/;
     const motDePasse = document.querySelector("input[name='motDePasse']").value;
     const parcours = document.querySelector("select[name='parcours']").value;
     const messageEmail = document.getElementById("message-email");
+
+    // Validation du format de l'email
+    if (!emailRegex.test(email)) {
+        messageEmail.textContent = "Adresse email invalide.";
+        messageEmail.classList.remove("hidden");
+        return;
+    }
 
     // Vérifie l'email universitaire
     if (email.endsWith("@etu.univ-lorraine.fr") || email.endsWith("@univ-lorraine.fr")) {

--- a/profile.html
+++ b/profile.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="fr" data-theme="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Profil - Gestion Moyennes</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: { sans: ["Inter", "sans-serif"] },
+        },
+      },
+      plugins: [daisyui],
+    }
+  </script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet" />
+</head>
+<body class="min-h-screen bg-base-200 text-base-content font-sans">
+
+<header class="flex justify-between items-center bg-base-100 px-6 py-4 shadow">
+  <div class="text-xl font-bold">
+    Profil
+  </div>
+  <div>
+    <a href="dashboard.html" class="btn btn-ghost">Tableau</a>
+  </div>
+</header>
+
+<main class="container mx-auto px-4 py-8 space-y-6">
+  <div class="card bg-base-100 shadow p-6">
+    <h2 class="text-2xl font-bold mb-4">Informations</h2>
+    <p><span class="font-semibold">Nom:</span> <span id="info-nom"></span></p>
+    <p><span class="font-semibold">Prénom:</span> <span id="info-prenom"></span></p>
+    <p><span class="font-semibold">Email:</span> <span id="info-email"></span></p>
+    <p><span class="font-semibold">Parcours:</span> <span id="info-parcours"></span></p>
+  </div>
+
+  <button id="deleteAccount" class="btn btn-error w-full">Supprimer mon compte</button>
+</main>
+
+<script src="js/utils.js"></script>
+<script src="js/profile.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create profile page to view account information
- add script to retrieve user info and delete the account
- add link to profile page from dashboard
- limit note precision to two decimals
- validate email format during registration

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6846c9e83b808323bf176b62801c9831